### PR TITLE
New ISMRMRD version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,11 @@ jobs:
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: |
-          ./build.sh
+          ./build.sh --include-user-channel
       - name: Build and push conda packages
         shell: bash -l {0}
         if: ${{ github.event_name == 'push' }}
         env:
           ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
         run: |
-          ./build.sh --token "$ANACONDA_TOKEN" --push
+          ./build.sh --include-user-channel --token "$ANACONDA_TOKEN" --push

--- a/global.yml
+++ b/global.yml
@@ -1,5 +1,4 @@
 channels:
-  - gadgetron
   - nvidia/label/cuda-11.6.0
   - conda-forge
   - bioconda

--- a/global.yml
+++ b/global.yml
@@ -1,4 +1,5 @@
 channels:
+  - gadgetron
   - nvidia/label/cuda-11.6.0
   - conda-forge
   - bioconda

--- a/ismrmrd/meta.yaml
+++ b/ismrmrd/meta.yaml
@@ -25,4 +25,11 @@ requirements:
     - fftw=3.3.9
 
 about:
-  home:
+  home: https://github.com/ismrmrd/ismrmrd
+  license: MIT
+  summary: 'ISMRM Raw Data Format (ISMRMRD)'
+  description: |
+    Libraries and tools for working with data in the ISMRM Raw Data (ISMRMRD or MRD).
+  dev_url: https://github.com/ismrmrd/ismrmrd
+  doc_url: https://github.com/ismrmrd/ismrmrd
+  doc_source_url: https://github.com/ismrmrd/ismrmrd/blob/master/README.md

--- a/ismrmrd/meta.yaml
+++ b/ismrmrd/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: ismrmrd
-  version: 1.5.0
+  version: 1.5.1
 
 source:
-  git_rev: 15caac2dc1b7248553ff3cff8d6af3bcac1aea5a
+  git_rev: a80c9595564b12fd1be91834247fab2c4ae37a91
   git_url: https://github.com/ismrmrd/ismrmrd
 
 requirements:


### PR DESCRIPTION
This PR pulls in ismrmrd 1.5.1. It also adds back the gadgetron channel in the list of channels for build. This is to allow us to keep the current version of the Gadgetron, which depends on ismrmrd=1.5.0. We are also adding some metadata to the ISMRMRD package. 