### PR TITLE
Added cpr recipe

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ Options:
 EOF
 }
 
-all_packages=("ismrmrd" "ismrmrd-python" "mrd-storage-server" "siemens_to_ismrmrd" "range-v3" "gadgetron-python" "gadgetron")
+all_packages=("ismrmrd" "ismrmrd-python" "mrd-storage-server" "siemens_to_ismrmrd" "range-v3" "cpr" "gadgetron-python" "gadgetron")
 packages_to_build=()
 user="gadgetron"
 

--- a/cpr/build.sh
+++ b/cpr/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+mkdir -p build
+cd build
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} ../
+ninja
+ninja install

--- a/cpr/meta.yaml
+++ b/cpr/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: cpr
+  version: 1.7.2
+
+source:
+  git_rev: beb9e98806bb84bcc130a2cebfbcbbc6ce62b335
+  git_url: https://github.com/libcpr/cpr
+
+requirements:
+  build:
+    - cmake>=3.20.0
+    - gcc_linux-64>=9.0.0
+    - gxx_linux-64>=9.0.0
+    - libcurl=7.79.1
+    - ninja=1.10.*
+
+  run:
+    - libcurl=7.79.1
+
+about:
+  home: https://github.com/libcpr/cpr
+  license: MIT
+  summary: 'C++ Requests: Curl for People'
+  description: |
+    C++ Requests is a simple wrapper around libcurl inspired by the excellent Python Requests project.
+  dev_url: https://github.com/libcpr/cpr
+  doc_url: https://github.com/libcpr/cpr
+  doc_source_url: https://github.com/libcpr/cpr/blob/master/README.md


### PR DESCRIPTION
This PR adds a basic recipe for [cpr](https://github.com/libcpr/cpr) which will be used to integrate with the mrd-storage-server in the Gadgetron.