### PR TITLE
Correct mrd-storage-server version

### DIFF
--- a/mrd-storage-server/meta.yaml
+++ b/mrd-storage-server/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: mrd-storage-server
-  version: 1.5.0
+  version: 0.0.7
 
 source:
   git_rev: v0.0.7


### PR DESCRIPTION
The version for the storage server version was the version of ismrmrd, not the storage server.