### PR TITLE
Roopchansinghv/osx 64 builds

### DIFF
--- a/cpr/build.sh
+++ b/cpr/build.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 
 mkdir -p build
 cd build
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} ../
+cmake -GNinja -DCMAKE_C_COMPILER=$CONDA_PREFIX/bin/clang -DCMAKE_CXX_COMPILER=$CONDA_PREFIX/bin/clang++ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} ../
 ninja
 ninja install

--- a/cpr/meta.yaml
+++ b/cpr/meta.yaml
@@ -8,9 +8,11 @@ source:
 
 requirements:
   build:
+    - clang>=12.0.0        # [osx]
+    - clangxx>=12.0.0      # [osx]
     - cmake>=3.20.0
-    - gcc_linux-64>=9.0.0
-    - gxx_linux-64>=9.0.0
+    - gcc_linux-64>=9.0.0  # [linux64]
+    - gxx_linux-64>=9.0.0  # [linux64]
     - libcurl=7.79.1
     - ninja=1.10.*
 

--- a/gadgetron-python/meta.yaml
+++ b/gadgetron-python/meta.yaml
@@ -8,14 +8,14 @@ source:
 
 requirements:
   build:
-    - python
+    - python>=3.6
     - multimethod>=1.0
     - numpy>=1.5.1
     - ismrmrd-python>=1.9.5
     - pyfftw>=0.11.0
 
   run:
-    - python
+    - python>=3.6
     - multimethod>=1.0
     - numpy>=1.5.1
     - ismrmrd-python>=1.9.5

--- a/ismrmrd/build.sh
+++ b/ismrmrd/build.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 
 mkdir -p build
 cd build
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} ../
+cmake -GNinja -DCMAKE_C_COMPILER=$CONDA_PREFIX/bin/clang -DCMAKE_CXX_COMPILER=$CONDA_PREFIX/bin/clang++ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} ../
 ninja
 ninja install

--- a/ismrmrd/meta.yaml
+++ b/ismrmrd/meta.yaml
@@ -9,10 +9,12 @@ source:
 requirements:
   build:
     - boost=1.76.0
-    - clang>=12.0.0
-    - clangxx>=12.0.0
+    - clang>=12.0.0        # [osx]
+    - clangxx>=12.0.0      # [osx]
     - cmake>=3.20.0
     - fftw=3.3.9
+    - gcc_linux-64>=9.0.0  # [linux64]
+    - gxx_linux-64>=9.0.0  # [linux64]
     - git
     - hdf5=1.10.6
     - ninja=1.10.*

--- a/ismrmrd/meta.yaml
+++ b/ismrmrd/meta.yaml
@@ -16,12 +16,10 @@ requirements:
     - git
     - hdf5=1.10.6
     - ninja=1.10.*
-    - pugixml=1.11.4
 
   run:
     - boost=1.76.0
     - hdf5=1.10.6
-    - pugixml=1.11.4
     - fftw=3.3.9
 
 about:

--- a/ismrmrd/meta.yaml
+++ b/ismrmrd/meta.yaml
@@ -9,10 +9,10 @@ source:
 requirements:
   build:
     - boost=1.76.0
+    - clang>=12.0.0
+    - clangxx>=12.0.0
     - cmake>=3.20.0
     - fftw=3.3.9
-    - gcc_linux-64>=9.0.0
-    - gxx_linux-64>=9.0.0
     - git
     - hdf5=1.10.6
     - ninja=1.10.*

--- a/siemens_to_ismrmrd/build.sh
+++ b/siemens_to_ismrmrd/build.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 
 mkdir -p build
 cd build
-cmake -G Ninja -DBUILD_DYNAMIC=ON -DCMAKE_PREFIX_PATH=${PREFIX} -DCMAKE_INSTALL_PREFIX=${PREFIX} ../
+cmake -G Ninja -DBUILD_DYNAMIC=ON -DCMAKE_C_COMPILER=$CONDA_PREFIX/bin/clang -DCMAKE_CXX_COMPILER=$CONDA_PREFIX/bin/clang++ -DCMAKE_PREFIX_PATH=${PREFIX} -DCMAKE_INSTALL_PREFIX=${PREFIX} ../
 ninja
 ninja install

--- a/siemens_to_ismrmrd/meta.yaml
+++ b/siemens_to_ismrmrd/meta.yaml
@@ -9,9 +9,11 @@ source:
 requirements:
   build:
     - boost=1.76.0
+    - clang>=12.0.0        # [osx]
+    - clangxx>=12.0.0      # [osx]
     - cmake>=3.20.0
-    - gcc_linux-64>=9.0.0
-    - gxx_linux-64>=9.0.0
+    - gcc_linux-64>=9.0.0  # [linux64] 
+    - gxx_linux-64>=9.0.0  # [linux64]
     - ismrmrd=1.5.1
     - libxml2=2.9.12
     - libxslt=1.1.33 


### PR DESCRIPTION
These changes allow Gadgetron's supporting packages to be also built on macOS.

The changes mainly consist of using preprocessing selectors to specify which packages work for Linux 64-bit builds, and which are to be used for macOS builds.

There are also changes to explicitly point to the compilers in the Conda environment.  If Apple's Developer tools are installed on macOS, the build system might point to these tools, depending on shell/environment configuration.