### PR TITLE
Removing python version spec on gadgetron-python

### DIFF
--- a/gadgetron-python/meta.yaml
+++ b/gadgetron-python/meta.yaml
@@ -8,14 +8,14 @@ source:
 
 requirements:
   build:
-    - python>=3.6
+    - python
     - multimethod>=1.0
     - numpy>=1.5.1
     - ismrmrd-python>=1.9.5
     - pyfftw>=0.11.0
 
   run:
-    - python>=3.6
+    - python
     - multimethod>=1.0
     - numpy>=1.5.1
     - ismrmrd-python>=1.9.5


### PR DESCRIPTION
There is a problem with specifying a specific version range of python since it will cause it to build a py310 package of gadgetron-python, which will not load.

This fixes #23 