### PR TITLE
ISMRMRD and Siemens converter to latest versions

### DIFF
--- a/global.yml
+++ b/global.yml
@@ -1,5 +1,5 @@
 channels:
-  - nvidia/label/cuda-11.6.0
+  - nvidia/label/cuda-11.6.1
   - conda-forge
   - bioconda
   - defaults

--- a/ismrmrd/meta.yaml
+++ b/ismrmrd/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.7.1
 
 source:
-  git_rev: v1.7.1
+  git_rev: v.1.7.1
   git_url: https://github.com/ismrmrd/ismrmrd
 
 requirements:

--- a/ismrmrd/meta.yaml
+++ b/ismrmrd/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: ismrmrd
-  version: 1.7.0
+  version: 1.7.1
 
 source:
-  git_rev: 31b3f1ed401761616fbf05df427bfa566fae06ae
+  git_rev: v1.7.1
   git_url: https://github.com/ismrmrd/ismrmrd
 
 requirements:

--- a/siemens_to_ismrmrd/meta.yaml
+++ b/siemens_to_ismrmrd/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: siemens_to_ismrmrd
-  version: 1.1.0
+  version: 1.2.2
 
 source:
-  git_rev: 5bc4aedfb8b53c35d26dae0972bcdabdba512451
+  git_rev: 7ccf32c1e1179891513ecd6e60523eefdf6a5cfc
   git_url: https://github.com/ismrmrd/siemens_to_ismrmrd
 
 requirements:
@@ -20,10 +20,17 @@ requirements:
     - ninja=1.10.*
 
   run:
-    - ismrmrd=1.7.0
+    - ismrmrd=1.7.1
     - boost=1.76.0
     - libxml2=2.9.12
     - libxslt=1.1.33 
 
 about:
-  home:
+  home: https://github.com/ismrmrd/siemens_to_ismrmrd
+  license: MIT
+  summary: 'Siemens to ISMRM Raw Data (ISMRMRD) converter'
+  description: |
+    Command line tool for converting Siemens raw data (*.dat) files to ISMRMRD files.
+  dev_url: https://github.com/ismrmrd/siemens_to_ismrmrd
+  doc_url: https://github.com/ismrmrd/siemens_to_ismrmrd
+  doc_source_url: https://github.com/ismrmrd/siemens_to_ismrmrd/blob/master/README.md


### PR DESCRIPTION
This PR pulls in the latest versions of ismrmrd (1.7.1) and the siemens converter (1.2.2). And we add some metadata to the converter conda package. 