### PR TITLE
Update storage server and cpr

### DIFF
--- a/cpr/build.sh
+++ b/cpr/build.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 
 mkdir -p build
 cd build
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} ../
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCPR_FORCE_USE_SYSTEM_CURL=ON -DCMAKE_INSTALL_PREFIX=${PREFIX} ../
 ninja
 ninja install

--- a/mrd-storage-server/meta.yaml
+++ b/mrd-storage-server/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: mrd-storage-server
-  version: 0.0.7
+  version: 0.0.8
 
 source:
-  git_rev: v0.0.7
+  git_rev: v0.0.8
   git_url: https://github.com/ismrmrd/mrd-storage-server
 
 requirements:


### PR DESCRIPTION
Updating storage server to version [0.0.8](https://github.com/ismrmrd/mrd-storage-server/releases/tag/v0.0.8). Also updating the CPR build recipe to not bundle libcurl. Without this option, it doesn't install CMake config files.