### PR TITLE
Update Gadgetron and fix nvidia dependency issues

### DIFF
--- a/gadgetron/meta.yaml
+++ b/gadgetron/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: gadgetron
-  version: 4.1.5
+  version: 4.2.1
 
 source:
-  git_rev: dff06e87388c2930359efebabf98c804cb0f00e3
+  git_rev: fcea9bd9b9f10781302a026d0fe3e4a0daf053ac
   git_url: https://github.com/gadgetron/gadgetron
 
 requirements:
@@ -11,17 +11,17 @@ requirements:
     - armadillo>=9.900.5
     - boost=1.76.0
     - cmake>=3.20.0
-    - cuda-libraries-dev      # [linux64]
-    - cuda-libraries          # [linux64]
-    - cuda-runtime            # [linux64]
-    - cuda-nvcc               # [linux64]
+    - cuda-libraries-dev=11.6.1      # [linux64]
+    - cuda-libraries=11.6.1          # [linux64]
+    - cuda-runtime=11.6.1            # [linux64]
+    - cuda-nvcc=11.6.112             # [linux64]
     - dcmtk=3.6.1
     - fftw=3.3.9
-    - gcc_linux-64=9.4.0      # [linux64]
+    - gcc_linux-64=9.4.0             # [linux64]
     - glew
     - gadgetron-python>=1.3.6
     - gmock>=1.10.0
-    - gxx_linux-64=9.4.0      # [linux64]
+    - gxx_linux-64=9.4.0             # [linux64]
     - gtest=1.10.0
     - ismrmrd=1.7.1
     - ismrmrd-python>=1.9.6
@@ -29,10 +29,11 @@ requirements:
     - libcurl=7.79.1
     - libxml2=2.9.12
     - libxslt=1.1.33
-    - mkl=2022.0.0            # [osx]
-    - mkl-include=2022.0.0    # [osx]
-    - mkl=2022.0.1            # [linux64]
-    - mkl-include=2022.0.1    # [linux64]
+    - mkl=2022.0.0                   # [osx]
+    - mkl-include=2022.0.0           # [osx]
+    - mkl=2022.0.1                   # [linux64]
+    - mkl-include=2022.0.1           # [linux64]
+    - mrd-storage-server=0.0.8
     - ninja=1.10.2
     - nlohmann_json=3.10.4
     - numpy>=1.22.0
@@ -40,14 +41,13 @@ requirements:
     - pyfftw>=0.12.0
     - python>=3.9.0
     - range-v3>=0.11.0
-    - rocksdb=6.13.3
     - sysroot_linux-64=2.17
 
   run:
     - armadillo=9.900.5
     - boost=1.76.0
-    - cuda-libraries          # [linux64]
-    - cuda-runtime            # [linux64]
+    - cuda-libraries=11.6.1          # [linux64]
+    - cuda-runtime=11.6.1            # [linux64]
     - dcmtk=3.6.1
     - fftw=3.3.9
     - gadgetron-python>=1.3.6
@@ -60,12 +60,12 @@ requirements:
     - libxslt=1.1.33
     - memkind=1.10.*
     - mkl=2022.0.1
+    - mrd-storage-server=0.0.8
     - numpy>=1.22.0
     - pugixml=1.11.4
     - pyfftw>=0.12.0
     - python>=3.9.0
-    - rocksdb=6.13.3
-    - sysroot_linux-64=2.17   # [linux64]
+    - sysroot_linux-64=2.17          # [linux64]
 
 about:
   home:

--- a/gadgetron/meta.yaml
+++ b/gadgetron/meta.yaml
@@ -11,6 +11,7 @@ requirements:
     - armadillo>=9.900.5
     - boost=1.76.0
     - cmake>=3.20.0
+    - cpr=1.7.2
     - cuda-libraries-dev=11.6.1      # [linux64]
     - cuda-libraries=11.6.1          # [linux64]
     - cuda-runtime=11.6.1            # [linux64]
@@ -23,6 +24,7 @@ requirements:
     - gmock>=1.10.0
     - gxx_linux-64=9.4.0             # [linux64]
     - gtest=1.10.0
+    - howardhinnant_date=3.0.1
     - ismrmrd=1.7.1
     - ismrmrd-python>=1.9.6
     - libblas=*=*mkl
@@ -46,6 +48,7 @@ requirements:
   run:
     - armadillo=9.900.5
     - boost=1.76.0
+    - cpr=1.7.2
     - cuda-libraries=11.6.1          # [linux64]
     - cuda-runtime=11.6.1            # [linux64]
     - dcmtk=3.6.1

--- a/global.yml
+++ b/global.yml
@@ -1,5 +1,5 @@
 channels:
-  - nvidia/label/cuda-11.6.1
+  - nvidia
   - conda-forge
   - bioconda
   - defaults


### PR DESCRIPTION
This PR pulls in latest version of Gadgetron which also fixes some nvidia dependency issues. 