### PR TITLE
To update CPR package version build for Gadgetron conda channel.

### DIFF
--- a/cpr/meta.yaml
+++ b/cpr/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: cpr
-  version: 1.7.2
+  version: 1.9.2
 
 source:
-  git_rev: beb9e98806bb84bcc130a2cebfbcbbc6ce62b335
+  git_rev: f88fd7737de3e640c61703eb57a0fa0ce00c60cd
   git_url: https://github.com/libcpr/cpr
 
 requirements:

--- a/cpr/meta.yaml
+++ b/cpr/meta.yaml
@@ -15,7 +15,6 @@ requirements:
     - gxx_linux-64>=9.0.0  # [linux64]
     - libcurl=7.79.1
     - ninja=1.10.*
-    - openssl=3.0.5        # [osx]
 
   run:
     - libcurl=7.79.1

--- a/cpr/meta.yaml
+++ b/cpr/meta.yaml
@@ -15,6 +15,7 @@ requirements:
     - gxx_linux-64>=9.0.0  # [linux64]
     - libcurl=7.79.1
     - ninja=1.10.*
+    - openssl=3.0.5        # [osx]
 
   run:
     - libcurl=7.79.1


### PR DESCRIPTION
Update CPR version to current - 1.9.2